### PR TITLE
Update Docker publish workflow and image references

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -67,13 +67,8 @@ jobs:
           cd Docker.Compose
           docker compose -f docker-compose.yml -f docker-compose.override.yml build
           
-      - name: Push to Docker Hub
+      - name: Push Images to Docker Hub
         if: github.ref == 'refs/heads/main'
         run: |
-          # Tag images with Docker Hub repository
-          docker tag askmeapi ${{ env.API_IMAGE_NAME }}:latest
-          docker tag askmeapp ${{ env.APP_IMAGE_NAME }}:latest
-          
-          # Push images
-          docker push ${{ env.API_IMAGE_NAME }}:latest
-          docker push ${{ env.APP_IMAGE_NAME }}:latest
+          cd Docker.Compose
+          docker compose -f docker-compose.yml -f docker-compose.override.yml push

--- a/Docker.Compose/docker-compose.yml
+++ b/Docker.Compose/docker-compose.yml
@@ -7,7 +7,8 @@ services:
      - app_network
 
  askme.api:
-   image: ${DOCKER_REGISTRY-}askmeapi
+ # image: ${DOCKER_REGISTRY-}askmeapi
+   image: odey114/askme-api:latest
    build:
      context: ..
      dockerfile: AskMe.API/Dockerfile
@@ -15,7 +16,8 @@ services:
      - app_network
 
  askme.app:
-   image: ${DOCKER_REGISTRY-}askmeapp
+ # image: ${DOCKER_REGISTRY-}askmeapp
+   image: odey114/askme-app:latest
    build:
      context: ..
      dockerfile: AskMe.APP/Dockerfile


### PR DESCRIPTION
Renamed the push step in `docker-publish.yml` to "Push Images to Docker Hub" and streamlined the image pushing process using Docker Compose. Updated `docker-compose.yml` to replace variable image references for `askme.api` and `askme.app` with specific images from Docker Hub (`odey114/askme-api:latest` and `odey114/askme-app:latest`).